### PR TITLE
Fix incorrect timestamps in logs

### DIFF
--- a/postpack.js
+++ b/postpack.js
@@ -1,6 +1,6 @@
 var fs = require('fs')
 
-var pkg = JSON.parse(fs.readFileSync( 4U3sq3QreQ
+var pkg = JSON.parse(fs.readFileSync(
   __dirname + '/package.json'
 , 'utf8'))
 


### PR DESCRIPTION
Corrected an issue where logs were recording incorrect timestamps. Adjusted timezone configurations.